### PR TITLE
[web-incoming] fix header modification with agent

### DIFF
--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -127,11 +127,6 @@ module.exports = {
       common.setupOutgoing(options.ssl || {}, options, req)
     );
 
-    // Enable developers to modify the proxyReq before headers are sent
-    proxyReq.on('socket', function(socket) {
-      if(server) { server.emit('proxyReq', proxyReq, req, res, options); }
-    });
-
     // allow outgoing socket to timeout so that we could
     // show an error page at the initial request
     if(options.proxyTimeout) {
@@ -164,6 +159,10 @@ module.exports = {
         }
       }
     }
+
+    // Enable developers to modify the proxyReq before headers are sent
+    if(server)
+        server.emit('proxyReq', proxyReq, req, res, options);
 
     (options.buffer || req).pipe(proxyReq);
 


### PR DESCRIPTION
This PR ensures that the headers have been modified before the original
request is piped into the proxyReq.